### PR TITLE
Make package framework-agnostic; add FastAPI/Starlette support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ jinja_partials.register_extensions(app)
 # ...
 ```
 
+You can also use this library in your FastAPI (or Starlette) project!
+```python
+from fastapi.templating import Jinja2Templates
+# or `from starlette.templating import Jinja2Templates`
+
+import jinja_partials
+
+templates = Jinja2Templates("tests/test_templates")
+
+jinja_partials.register_starlette_extensions(templates)
+# ...
+```
+
 Next, you define your main HTML (Jinja2) templates as usual. Then 
 define your partial templates. I recommend locating and naming them accordingly:
 

--- a/jinja_partials/__init__.py
+++ b/jinja_partials/__init__.py
@@ -4,28 +4,70 @@ jinja_partials - Simple reuse of partial HTML page templates in the Jinja templa
 
 __version__ = '0.1.1'
 __author__ = 'Michael Kennedy <michael@talkpython.fm>'
-__all__ = ['register_extensions', 'render_partial', 'PartialsException', ]
+__all__ = [
+    'register_extensions',
+    'register_starlette_extensions',
+    'register_fastapi_extensions',
+    'render_partial',
+    'generate_render_partial',
+    'PartialsException',
+]
 
-import flask as __flask
+from functools import partial
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+import starlette
 from jinja2 import Markup as Markup
 
-has_registered_extensions = False
+try:
+    import flask
+except ImportError:
+    flask = None
+
+if TYPE_CHECKING:
+    from flask import Flask
+    from starlette.templating import Jinja2Templates
+
 
 
 class PartialsException(Exception):
     pass
 
 
-def render_partial(template_name: str, **data) -> Markup:
-    if not has_registered_extensions:
-        raise PartialsException("You must call register_extensions() before this function can be used.")
+def render_partial(
+    template_name: str,
+    renderer: Optional[Callable[..., Any]] = None,
+    **data: Any,
+) -> Markup:
+    if renderer is None:
+        if flask is None:
+            raise PartialsException("No renderer specified")
+        else:
+            renderer = flask.render_template
 
-    html = __flask.render_template(template_name, **data)
-    return Markup(html)
+    return Markup(renderer(template_name, **data))
 
 
-def register_extensions(app: __flask.Flask):
-    global has_registered_extensions
+def generate_render_partial(renderer: Callable[..., Any]) -> Callable[..., Markup]:
+    return partial(render_partial, renderer=renderer)  # type: ignore
 
-    has_registered_extensions = True
-    app.jinja_env.globals.update(render_partial=render_partial)
+
+def register_extensions(app: "Flask"):
+    if flask is None:
+        raise PartialsException("Install Flask to use `register_extensions`")
+
+    app.jinja_env.globals.update(render_partial=generate_render_partial(flask.render_template))
+
+
+def register_starlette_extensions(templates: "Jinja2Templates"):
+    if starlette is None:
+        raise PartialsException("Install Starlette to use `register_starlette_extensions`")
+
+    def renderer(template_name: str, **data: Any) -> str:
+        return templates.get_template(template_name).render(**data)
+
+    templates.env.globals.update(render_partial=generate_render_partial(renderer))
+
+
+def register_fastapi_extensions(templates: "Jinja2Templates"):
+    register_starlette_extensions(templates)

--- a/jinja_partials/__init__.py
+++ b/jinja_partials/__init__.py
@@ -2,7 +2,7 @@
 jinja_partials - Simple reuse of partial HTML page templates in the Jinja template language for Python web frameworks.
 """
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __author__ = 'Michael Kennedy <michael@talkpython.fm>'
 __all__ = [
     'register_extensions',

--- a/jinja_partials/__init__.py
+++ b/jinja_partials/__init__.py
@@ -7,7 +7,6 @@ __author__ = 'Michael Kennedy <michael@talkpython.fm>'
 __all__ = [
     'register_extensions',
     'register_starlette_extensions',
-    'register_fastapi_extensions',
     'render_partial',
     'generate_render_partial',
     'PartialsException',

--- a/jinja_partials/__init__.py
+++ b/jinja_partials/__init__.py
@@ -16,13 +16,17 @@ __all__ = [
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
-import starlette
-from jinja2 import Markup as Markup
+from markupsafe import Markup as Markup
 
 try:
     import flask
 except ImportError:
     flask = None
+
+try:
+    import starlette
+except ImportError:
+    starlette = None
 
 if TYPE_CHECKING:
     from flask import Flask
@@ -41,7 +45,7 @@ def render_partial(
 ) -> Markup:
     if renderer is None:
         if flask is None:
-            raise PartialsException("No renderer specified")
+            raise PartialsException('No renderer specified')
         else:
             renderer = flask.render_template
 
@@ -49,25 +53,21 @@ def render_partial(
 
 
 def generate_render_partial(renderer: Callable[..., Any]) -> Callable[..., Markup]:
-    return partial(render_partial, renderer=renderer)  # type: ignore
+    return partial(render_partial, renderer=renderer)
 
 
-def register_extensions(app: "Flask"):
+def register_extensions(app: 'Flask'):
     if flask is None:
-        raise PartialsException("Install Flask to use `register_extensions`")
+        raise PartialsException('Install Flask to use `register_extensions`')
 
     app.jinja_env.globals.update(render_partial=generate_render_partial(flask.render_template))
 
 
-def register_starlette_extensions(templates: "Jinja2Templates"):
+def register_starlette_extensions(templates: 'Jinja2Templates'):
     if starlette is None:
-        raise PartialsException("Install Starlette to use `register_starlette_extensions`")
+        raise PartialsException('Install Starlette to use `register_starlette_extensions`')
 
     def renderer(template_name: str, **data: Any) -> str:
         return templates.get_template(template_name).render(**data)
 
     templates.env.globals.update(render_partial=generate_render_partial(renderer))
-
-
-def register_fastapi_extensions(templates: "Jinja2Templates"):
-    register_starlette_extensions(templates)

--- a/jinja_partials/__init__.py
+++ b/jinja_partials/__init__.py
@@ -2,7 +2,7 @@
 jinja_partials - Simple reuse of partial HTML page templates in the Jinja template language for Python web frameworks.
 """
 
-__version__ = '0.1.2'
+__version__ = '0.1.1'
 __author__ = 'Michael Kennedy <michael@talkpython.fm>'
 __all__ = [
     'register_extensions',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 pytest
 pytest-clarity
+flask
+fastapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 jinja2
-flask

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from functools import partial
+from typing import Any
 
 import flask
 # noinspection PyPackageRequirements
@@ -6,6 +8,7 @@ import pytest
 
 import jinja_partials
 
+from fastapi.templating import Jinja2Templates
 
 @pytest.fixture
 def registered_extension():
@@ -24,3 +27,15 @@ def registered_extension():
 
         # Roll back the fact that we registered the extensions for future tests.
         jinja_partials.has_registered_extensions = False
+
+
+@pytest.fixture
+def fastapi_render_partial():
+    templates = Jinja2Templates("tests/test_templates")
+    jinja_partials.register_fastapi_extensions(templates)
+
+    def renderer(template_name: str, **data: Any) -> str:
+        return templates.get_template(template_name).render(**data) # type: ignore
+
+    return partial(jinja_partials.render_partial, renderer=renderer)
+    

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -32,7 +32,7 @@ def registered_extension():
 
 @pytest.fixture
 def starlette_render_partial():
-    templates = Jinja2Templates('tests/test_templates')
+    templates = Jinja2Templates(Path(__file__).parent / "test_templates")
     jinja_partials.register_starlette_extensions(templates)
 
     def renderer(template_name: str, **data: Any) -> str:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -29,13 +29,14 @@ def registered_extension():
         jinja_partials.has_registered_extensions = False
 
 
+
 @pytest.fixture
-def fastapi_render_partial():
-    templates = Jinja2Templates("tests/test_templates")
-    jinja_partials.register_fastapi_extensions(templates)
+def starlette_render_partial():
+    templates = Jinja2Templates('tests/test_templates')
+    jinja_partials.register_starlette_extensions(templates)
 
     def renderer(template_name: str, **data: Any) -> str:
-        return templates.get_template(template_name).render(**data) # type: ignore
+        return templates.get_template(template_name).render(**data)
 
     return partial(jinja_partials.render_partial, renderer=renderer)
     

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,10 +1,12 @@
+from typing import Any, Callable
+
 import jinja2
 # noinspection PyPackageRequirements
 import pytest as pytest
 from jinja2 import TemplateNotFound
 
 import jinja_partials
-from fixtures import registered_extension
+from fixtures import fastapi_render_partial, registered_extension
 
 
 def test_render_empty(registered_extension):
@@ -43,5 +45,23 @@ def test_missing_template(registered_extension):
 
 
 def test_not_registered():
-    with pytest.raises(jinja_partials.PartialsException):
+    with pytest.raises(Exception):
         jinja_partials.render_partial('doesnt-matter.pt', message=7)
+
+
+def test_fastapi_with_layout(fastapi_render_partial: Callable[..., Any]):
+    value_text = "The message is clear"
+    html: jinja2.Markup = fastapi_render_partial('render/with_layout.html', message=value_text)
+    assert '<title>Jinja Partials Test Template</title>' in html
+    assert value_text in html
+
+
+def test_fastapi_recursive(fastapi_render_partial: Callable[..., Any]):
+    value_text = "The message is clear"
+    inner_text = "The message is recursive"
+
+    html: jinja2.Markup = fastapi_render_partial('render/recursive.html',
+                                                        message=value_text,
+                                                        inner=inner_text)
+    assert value_text in html
+    assert inner_text in html

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,29 +1,30 @@
-from typing import Any, Callable
+import sys
+from types import SimpleNamespace
+from typing import Callable
 
-import jinja2
 # noinspection PyPackageRequirements
 import pytest as pytest
 from jinja2 import TemplateNotFound
+from markupsafe import Markup
+from fixtures import registered_extension, starlette_render_partial
 
 import jinja_partials
-from fixtures import fastapi_render_partial, registered_extension
-
 
 def test_render_empty(registered_extension):
-    html: jinja2.Markup = jinja_partials.render_partial('render/bare.html')
+    html: Markup = jinja_partials.render_partial('render/bare.html')
     assert '<h1>This is bare HTML fragment</h1>' in html
 
 
 def test_render_with_data(registered_extension):
     name = 'Sarah'
     age = 32
-    html: jinja2.Markup = jinja_partials.render_partial('render/with_data.html', name=name, age=age)
+    html: Markup = jinja_partials.render_partial('render/with_data.html', name=name, age=age)
     assert f'<span>Your name is {name} and age is {age}</span>' in html
 
 
 def test_render_with_layout(registered_extension):
     value_text = "The message is clear"
-    html: jinja2.Markup = jinja_partials.render_partial('render/with_layout.html', message=value_text)
+    html: Markup = jinja_partials.render_partial('render/with_layout.html', message=value_text)
     assert '<title>Jinja Partials Test Template</title>' in html
     assert value_text in html
 
@@ -32,9 +33,9 @@ def test_render_recursive(registered_extension):
     value_text = "The message is clear"
     inner_text = "The message is recursive"
 
-    html: jinja2.Markup = jinja_partials.render_partial('render/recursive.html',
-                                                        message=value_text,
-                                                        inner=inner_text)
+    html: Markup = jinja_partials.render_partial('render/recursive.html',
+                                                message=value_text,
+                                                inner=inner_text)
     assert value_text in html
     assert inner_text in html
 
@@ -49,19 +50,38 @@ def test_not_registered():
         jinja_partials.render_partial('doesnt-matter.pt', message=7)
 
 
-def test_fastapi_with_layout(fastapi_render_partial: Callable[..., Any]):
-    value_text = "The message is clear"
-    html: jinja2.Markup = fastapi_render_partial('render/with_layout.html', message=value_text)
-    assert '<title>Jinja Partials Test Template</title>' in html
-    assert value_text in html
-
-
-def test_fastapi_recursive(fastapi_render_partial: Callable[..., Any]):
+def test_starlette_render_recursive(starlette_render_partial: Callable[..., Markup]):
     value_text = "The message is clear"
     inner_text = "The message is recursive"
 
-    html: jinja2.Markup = fastapi_render_partial('render/recursive.html',
-                                                        message=value_text,
-                                                        inner=inner_text)
+    html = starlette_render_partial(
+        'render/recursive.html',
+        message=value_text,
+        inner=inner_text,
+    )
     assert value_text in html
     assert inner_text in html
+
+
+def test_register_extensions_raises_if_flask_is_not_installed():
+    sys.modules['flask'] = None
+    del sys.modules['jinja_partials']
+    import jinja_partials
+    with pytest.raises(
+        jinja_partials.PartialsException,
+        match='Install Flask to use `register_extensions`',
+    ):
+        jinja_partials.register_extensions(SimpleNamespace())
+    del sys.modules['flask']
+
+
+def test_register_extensions_raises_if_flask_is_not_installed():
+    sys.modules['starlette'] = None
+    del sys.modules['jinja_partials']
+    import jinja_partials
+    with pytest.raises(
+        jinja_partials.PartialsException,
+        match='Install Starlette to use `register_starlette_extensions`',
+    ):
+        jinja_partials.register_starlette_extensions(SimpleNamespace())
+    del sys.modules['starlette']

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -10,6 +10,7 @@ from fixtures import registered_extension, starlette_render_partial
 
 import jinja_partials
 
+
 def test_render_empty(registered_extension):
     html: Markup = jinja_partials.render_partial('render/bare.html')
     assert '<h1>This is bare HTML fragment</h1>' in html
@@ -34,8 +35,8 @@ def test_render_recursive(registered_extension):
     inner_text = "The message is recursive"
 
     html: Markup = jinja_partials.render_partial('render/recursive.html',
-                                                message=value_text,
-                                                inner=inner_text)
+                                                 message=value_text,
+                                                 inner=inner_text)
     assert value_text in html
     assert inner_text in html
 
@@ -68,20 +69,20 @@ def test_register_extensions_raises_if_flask_is_not_installed():
     del sys.modules['jinja_partials']
     import jinja_partials
     with pytest.raises(
-        jinja_partials.PartialsException,
-        match='Install Flask to use `register_extensions`',
+            jinja_partials.PartialsException,
+            match='Install Flask to use `register_extensions`',
     ):
         jinja_partials.register_extensions(SimpleNamespace())
     del sys.modules['flask']
 
 
-def test_register_extensions_raises_if_flask_is_not_installed():
+def test_register_extensions_raises_if_starlette_is_not_installed():
     sys.modules['starlette'] = None
     del sys.modules['jinja_partials']
     import jinja_partials
     with pytest.raises(
-        jinja_partials.PartialsException,
-        match='Install Starlette to use `register_starlette_extensions`',
+            jinja_partials.PartialsException,
+            match='Install Starlette to use `register_starlette_extensions`',
     ):
         jinja_partials.register_starlette_extensions(SimpleNamespace())
     del sys.modules['starlette']


### PR DESCRIPTION
@mikeckennedy When I was watching HTMX + Flask course, I decided to do it using FastAPI (love it too much). Your library was heavily dependant on Flask, this PR solves it. 

I hadn't have time to test yet is will this work with FastAPI or Flask without each other 😅 And also didn't test on Python <3.10

- [x] Test with FastAPI without Flask and vise versa
- [x] Test on Python <3.10
- [x] Add example to README.md

Also I fixed this deprecation warning:
```console
.../jinja_partials/jinja_partials/__init__.py:52: DeprecationWarning: 'jinja2.Markup' is deprecated and will be removed in Jinja 3.1. Import 'markupsafe.Markup' instead.
    return Markup(renderer(template_name, **data))
```