### PR TITLE
Add Register Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ jinja_partials.register_starlette_extensions(templates)
 # ...
 ```
 
+Or directly using a jijna environment!
+```python
+import jinja_partials
+from jinja2 import Environment, FileSystemLoader
+
+environment = Environment(loader=FileSystemLoader("tests/test_templates"))
+jinja_partials.register_environment(environment)
+# ...
+```
+
 Next, you define your main HTML (Jinja2) templates as usual. Then 
 define your partial templates. I recommend locating and naming them accordingly:
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,14 +1,16 @@
-from pathlib import Path
 from functools import partial
+from pathlib import Path
 from typing import Any
 
 import flask
+
 # noinspection PyPackageRequirements
 import pytest
+from fastapi.templating import Jinja2Templates
+from jinja2 import Environment, FileSystemLoader
 
 import jinja_partials
 
-from fastapi.templating import Jinja2Templates
 
 @pytest.fixture
 def registered_extension():
@@ -39,4 +41,13 @@ def starlette_render_partial():
         return templates.get_template(template_name).render(**data)
 
     return partial(jinja_partials.render_partial, renderer=renderer)
-    
+
+@pytest.fixture
+def environment_render_partial():
+    environment = Environment(loader=FileSystemLoader(Path(__file__).parent / "test_templates"))
+    jinja_partials.register_environment(environment)
+
+    def renderer(template_name: str, **data: Any) -> str:
+        return environment.get_template(template_name).render(**data)
+
+    return partial(jinja_partials.render_partial, renderer=renderer)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -4,9 +4,9 @@ from typing import Callable
 
 # noinspection PyPackageRequirements
 import pytest as pytest
+from fixtures import environment_render_partial, registered_extension, starlette_render_partial
 from jinja2 import TemplateNotFound
 from markupsafe import Markup
-from fixtures import registered_extension, starlette_render_partial
 
 import jinja_partials
 
@@ -63,6 +63,17 @@ def test_starlette_render_recursive(starlette_render_partial: Callable[..., Mark
     assert value_text in html
     assert inner_text in html
 
+def test_register_environment(environment_render_partial: Callable[..., Markup]):
+    value_text = "The message is clear"
+    inner_text = "The message is recursive"
+
+    html = environment_render_partial(
+        'render/recursive.html',
+        message=value_text,
+        inner=inner_text,
+    )
+    assert value_text in html
+    assert inner_text in html
 
 def test_register_extensions_raises_if_flask_is_not_installed():
     sys.modules['flask'] = None
@@ -86,3 +97,4 @@ def test_register_extensions_raises_if_starlette_is_not_installed():
     ):
         jinja_partials.register_starlette_extensions(SimpleNamespace())
     del sys.modules['starlette']
+


### PR DESCRIPTION
Adds register_environment function to allow rendering directly from jinja without flask/fastapi. Fixes https://github.com/mikeckennedy/jinja_partials/issues/4

I added a markup: bool to control adding the markup safe or not. Defaults to true on flask/fastapi stuff for backwards compatibility. Defaults to false on register_environment since this may be used as a more general jinja usecase

Example usage:
```
import jinja_partials
from jinja2 import Environment, FileSystemLoader

environment = Environment(loader=FileSystemLoader("foo"))
jinja_partials.register_environment(environment)

template = environment.get_template("foo.jinja2")

print(template.render(fooarg="fooarg", bararg="bararg"))
```


P.S. I didn't realize who's project this was until I saw the \_\_author__ in the init. Love the podcast!