### PR TITLE
Wrap setting `requires_list` with a try except

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,11 @@ def read(filename):
         return re.sub(text_type(r':[a-z]+:`~?(.*?)`'), text_type(r'``\1``'), fd.read())
 
 
-with open('./requirements.txt', 'r', encoding='utf-8') as fin:
-    requires_list = [line.strip() for line in fin if line and line.strip()]
+try:
+    with open('./requirements.txt', 'r', encoding='utf-8') as fin:
+        requires_list = [line.strip() for line in fin if line and line.strip()]
+except Exception as e:
+    requires_list = ['jinja2']
 
 
 def read_version():


### PR DESCRIPTION
This is useful when the package is being installed from a directory where `requirements.txt` isn't accessible.

Some additional context, I'm trying to create a `jinja_partials` conda package (via conda-forge) and the conda-forge CI installs packages in a different directory than where the source is stored, so it throws an exception when trying to read the `requirements.txt` file. (If you're really curious you can see it here https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=913810&view=logs&j=6f142865-96c3-535c-b7ea-873d86b887bd&t=22b0682d-ab9e-55d7-9c79-49f3c3ba4823&l=800 )